### PR TITLE
Adding composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+	"name": "lemmingzshadow/php-websocket",
+	"type": "library",
+	"description": "A simple PHP WebSocket implementation for PHP 5.3",
+	"keywords": ["websockets"],
+	"homepage": "http://github.com/lemmingzshadow/php-websocket",
+	"license": "WTFPL",
+	"authors": [
+		{
+			"name": "Simon Samtleben",
+			"email": "web@lemmingzshadow.net",
+			"homepage": "http://lemmingzshadow.net"
+		}
+	],
+	"require": {
+		"php": ">=5.3"
+	},
+	"autoload": {
+		"psr-0": {
+			"WebSocket": "server/lib/"
+		}
+	}
+}


### PR DESCRIPTION
Hi lemmingzshadow, 
Are you interested in adding a Composer.json file to make php-websocket a reusable package? I've added one in this pull request for you to customise if you like.

This is used with [Composer](http://packagist.org/about-composer). Composer manages PHP-packages and their dependencies. With it, someone can build a project that uses php-websocket and distribute it easily.

Composer also ties in to [Packagist](http://packagist.org). You can register php-websocket there so other users can find it easily.

If you don't want any of this, that is fine too. Just close/delete this pull request. :)

Thanks!
