### PR TITLE
Mark clients and applications as protected

### DIFF
--- a/server/lib/WebSocket/Server.php
+++ b/server/lib/WebSocket/Server.php
@@ -9,8 +9,8 @@ namespace WebSocket;
  */
 class Server extends Socket
 {   
-    private $clients = array();
-    private $applications = array();
+    protected $clients = array();
+    protected $applications = array();
 	private $_ipStorage = array();
 	private $_requestStorage = array();
 	


### PR DESCRIPTION
It's very useful for subclasses of `WebSocket\Server` to have access to the whole array of `$this->clients` and `$this->applications`.

If you'd rather not open up the protected API this much, I'd be willing to consider implementing other alternatives, such as returning iterators or the arrays through an accessor method.

For background: I'm working on integrating php-websocket into Symfony2's Service Container, and I'd like to be able to do convenience methods in my injected Server subclass.
