### PR TITLE
Adds a connection factory method to the server

### DIFF
--- a/server/lib/WebSocket/Server.php
+++ b/server/lib/WebSocket/Server.php
@@ -27,6 +27,17 @@ class Server extends Socket
         $this->log('Server created');
     }
 
+    /**
+     * Creates a connection from a socket resource
+     *
+     * @param resource $resource A socket resource
+     * @return Connection
+     */
+    protected function createConnection($resource)
+    {
+        return new Connection($this, $resource);
+    }
+
 	/**
 	 * Main server method. Listens for connections, handles connectes/disconnectes, e.g.
 	 */
@@ -47,7 +58,7 @@ class Server extends Socket
 					}
 					else
 					{
-						$client = new Connection($this, $ressource);
+						$client = $this->createConnection($ressource);
 						$this->clients[(int)$ressource] = $client;
 						$this->allsockets[] = $ressource;
 						


### PR DESCRIPTION
Abstracting the creation of connection objects to a protected method is nicer for `WebSocket\Server` subclasses. Subclasses can override `createConnection()` to replace the Connection class.

Without this abstraction, the `Server` and `Connection` classes are tightly coupled, and the whole lengthy `run()` method would need to be copy-pasted into the subclass to use a different `Connection` class.
