### PR TITLE
Patch for Google Chrome 20

### DIFF
--- a/server/lib/WebSocket/Connection.php
+++ b/server/lib/WebSocket/Connection.php
@@ -123,8 +123,8 @@ class Connection
 		$response = "HTTP/1.1 101 Switching Protocols\r\n";
 		$response.= "Upgrade: websocket\r\n";
 		$response.= "Connection: Upgrade\r\n";
-		$response.= "Sec-WebSocket-Accept: " . $secAccept . "\r\n";
-		$response.= "Sec-WebSocket-Protocol: " . substr($path, 1) . "\r\n\r\n";		
+		$response.= "Sec-WebSocket-Accept: " . $secAccept . "\r\n\r\n";
+		
 		if(false === ($this->server->writeBuffer($this->socket, $response)))
 		{
 			return false;


### PR DESCRIPTION
Websocket server should not send Sec-WebSocket-Protocol header unless client requested it. http://tools.ietf.org/html/rfc6455#section-4.2.2  /subprotocol/ description
