### PR TITLE
Add the ability to run periodic tasks

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -61,6 +61,11 @@ class Server extends Socket
     private $maxRequestsPerMinute = 50;
 
     /**
+     * @var TimerCollection $timers
+     */
+    private $timers;
+
+    /**
      * @param string $host
      * @param int $port
      */
@@ -68,6 +73,7 @@ class Server extends Socket
     {
         parent::__construct($host, $port);
         $this->log('Server created');
+        $this->timers = new TimerCollection();
     }
 
     /**
@@ -92,6 +98,7 @@ class Server extends Socket
         while (true) {
             $changed_sockets = $this->allsockets;
             @stream_select($changed_sockets, $write = null, $except = null, 0, 5000);
+            $this->timers->runAll();
             foreach ($changed_sockets as $socket) {
                 if ($socket == $this->master) {
                     if (($ressource = stream_socket_accept($this->master)) === false) {
@@ -489,5 +496,10 @@ class Server extends Socket
     public function getMaxClients(): int
     {
         return $this->maxClients;
+    }
+
+    public function addTimer(int $interval, callable $task): void
+    {
+        $this->timers->addTimer(new Timer($interval, $task));
     }
 }

--- a/src/Timer.php
+++ b/src/Timer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bloatless\WebSocket;
+
+final class Timer
+{
+    private $interval;
+    private $task;
+    private $lastRun;
+
+    public function __construct(int $interval, callable $task)
+    {
+        $this->interval = $interval;
+        $this->task = $task;
+        $this->lastRun = 0;
+    }
+
+    public function run(): void
+    {
+        $now = round(microtime(true) * 1000);
+        if ($now - $this->lastRun < $this->interval) {
+            return;
+        }
+
+        $this->lastRun = $now;
+
+        $task = $this->task;
+        $task();
+    }
+}

--- a/src/TimerCollection.php
+++ b/src/TimerCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bloatless\WebSocket;
+
+final class TimerCollection
+{
+    /**
+     * @var Timer[]
+     */
+    private $timers;
+
+    public function __construct(array $timers = [])
+    {
+        $this->timers = $timers;
+    }
+
+    public function addTimer(Timer $timer)
+    {
+        $this->timers[] = $timer;
+    }
+
+    public function runAll(): void
+    {
+        foreach ($this->timers as $timer) {
+            $timer->run();
+        }
+    }
+}


### PR DESCRIPTION
When running websockets on Heroku, the connections are subject to a timeout:

https://devcenter.heroku.com/articles/websockets#timeouts

The solution is to periodically send messages over the connection to keep it alive.

Usage:
```php
$app = new SomeContainer();

$server = new Server(...);
$server->registerApplication('name', ...);
$server->addTimer(30000, function () use ($app) {
    $app->doSomething();
});
$server->run();
```