### PR TITLE
fix StatusApplication sessions storage collision with same port but different IP

### DIFF
--- a/src/Application/StatusApplication.php
+++ b/src/Application/StatusApplication.php
@@ -46,7 +46,8 @@ class StatusApplication extends Application
     {
         $id = $client->getClientId();
         $this->clients[$id] = $client;
-        $this->sendServerinfo($client);
+        // no longer send serverinfo at connect ( d.roche )
+        //$this->sendServerinfo($client);
     }
 
     /**
@@ -70,7 +71,10 @@ class StatusApplication extends Application
      */
     public function onData(string $data, Connection $client): void
     {
-        // currently not in use...
+        // modified by d.roche to send server info on any received data...
+        foreach ($this->clients as $cli1) {
+            $this->sendServerinfo($cli1);
+        }
     }
 
     /**

--- a/src/Application/StatusApplication.php
+++ b/src/Application/StatusApplication.php
@@ -97,7 +97,7 @@ class StatusApplication extends Application
      */
     public function clientConnected(string $ip, int $port): void
     {
-        $this->serverClients[$port] = $ip;
+        $this->serverClients[$ip.":".$port] = date("U");
         $this->serverClientCount++;
         $this->statusMsg('Client connected: ' . $ip . ':' . $port);
         $data = [
@@ -118,10 +118,10 @@ class StatusApplication extends Application
      */
     public function clientDisconnected(string $ip, int $port): void
     {
-        if (!isset($this->serverClients[$port])) {
+        if (!isset($this->serverClients[$ip.":".$port])) {
             return;
         }
-        unset($this->serverClients[$port]);
+        unset($this->serverClients[$ip.":".$port]);
         $this->serverClientCount--;
         $this->statusMsg('Client disconnected: ' . $ip . ':' . $port);
         $data = [

--- a/src/Client.php
+++ b/src/Client.php
@@ -81,6 +81,53 @@ class Client
     }
 
     /**
+     * wait for data 
+     * added by d.roche@girondenumerique.fr
+     *
+     * @param int $timeout  ( sec )
+     * @return bool
+     */
+    public function wait(int $timeout = null): bool
+    {
+        if ($this->connected === false) {
+            trigger_error("Not connected", E_USER_WARNING);
+            return false;
+        }
+        $rsocks = Array($this->socket);
+        $changed = @stream_select($rsocks, $write = null, $except = null, $timeout);
+        if ( $changed > 0 ) {
+            return(true);
+        } else {
+            return(false);
+        }
+    }
+
+    /**
+     * read data from remote server.
+     * added by d.roche@girondenumerique.fr
+     *
+     * @param int $len
+     * @return string
+     */
+    public function readData(int $len = 4096): string
+    {
+        if ($this->connected === false) {
+            trigger_error("Not connected", E_USER_WARNING);
+            return false;
+        }
+        $ret = '';
+
+        $buffer = fread($this->socket, $len);
+        if ( ! empty($buffer) ) {
+            $decbuff = $this->hybi10Decode($buffer);
+            if ( $decbuff['type'] == "text" ) {
+                    $ret = $decbuff['payload'];
+            }
+        }
+        return $ret;
+    }
+
+    /**
      * Connects to a websocket server.
      *
      * @param string $host


### PR DESCRIPTION
the serverClients array store client connections by port, thus if another client ( with different IP ) is connecting with the same port as a previous one -> the first client is lost !