### PR TITLE
Fix Warning on PHP8

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -16,7 +16,7 @@ abstract class Application implements ApplicationInterface
         // singleton construct required this method to be protected/private
     }
 
-    final private function __clone()
+    final protected function __clone()
     {
         // singleton construct required this method to be protected/private
     }


### PR DESCRIPTION
PHP8 emits a warning when `final` and `private` are used on the same method.

```
Warning: Private methods cannot be final as they are never overridden by other classes in {file} on line {line}
```

Example: https://3v4l.org/p2Ccp