### PR TITLE
Remove final from private magic method

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -16,7 +16,7 @@ abstract class Application implements ApplicationInterface
         // singleton construct required this method to be protected/private
     }
 
-    final protected function __clone()
+    protected function __clone()
     {
         // singleton construct required this method to be protected/private
     }


### PR DESCRIPTION
In order to fix PHP Warning:  Private methods cannot be final as they are never overridden by other classes in .../src/Application/Application.php on line 19

Fixes #36 