### PR TITLE
Make IPC optional

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -37,9 +37,9 @@ class Server
     private $icpSocket;
 
     /**
-     * @var string $ipcSocketPath
+     * @var null|string $ipcSocketPath
      */
-    private string $ipcSocketPath;
+    private ?string $ipcSocketPath;
 
     /**
      * @var string $ipcOwner If set, owner of the ipc socket will be changed to this value.
@@ -114,12 +114,12 @@ class Server
     /**
      * @param string $host
      * @param int $port
-     * @param string $ipcSocketPath
+     * @param null|string $ipcSocketPath
      */
     public function __construct(
         string $host = 'localhost',
         int $port = 8000,
-        string $ipcSocketPath = '/tmp/phpwss.sock'
+        ?string $ipcSocketPath = '/tmp/phpwss.sock'
     ) {
         $this->host = $host;
         $this->port = $port;
@@ -137,12 +137,13 @@ class Server
     {
         ob_implicit_flush();
         $this->createSocket($this->host, $this->port);
-        $this->openIPCSocket($this->ipcSocketPath);
+        if ($this->ipcSocketPath)
+            $this->openIPCSocket($this->ipcSocketPath);
         $this->log('Server created');
 
         while (true) {
             $this->timers->runAll();
-          
+
             $changed_sockets = $this->allsockets;
             @stream_select($changed_sockets, $write, $except, 0, 5000);
             foreach ($changed_sockets as $socket) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -124,6 +124,7 @@ class Server
         $this->host = $host;
         $this->port = $port;
         $this->ipcSocketPath = $ipcSocketPath;
+        $this->timers = new TimerCollection();
     }
 
     /**
@@ -137,7 +138,6 @@ class Server
         ob_implicit_flush();
         $this->createSocket($this->host, $this->port);
         $this->openIPCSocket($this->ipcSocketPath);
-        $this->timers = new TimerCollection();
         $this->log('Server created');
 
         while (true) {


### PR DESCRIPTION
By passing `null` as the IPC path, opening a UNIX socket can be skipped.

I want to be able to do this in order to start a websocket server on Windows without it failing to open a UNIX socket.

This change is backwards-compatible and the earliest supported version is PHP 7.4.