### PR TITLE
Added LoggerAwareInterface support and abstract implementation

### DIFF
--- a/src/Application/LoggerAwareApplication.php
+++ b/src/Application/LoggerAwareApplication.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Bloatless\WebSocket\Application;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+abstract class LoggerAwareApplication extends Application implements LoggerAwareInterface {
+    private LoggerInterface $logger;
+
+    protected function __construct()
+    {
+        parent::__construct();
+
+        $this->logger = new NullLogger();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+}

--- a/src/Application/StatusApplication.php
+++ b/src/Application/StatusApplication.php
@@ -6,7 +6,7 @@ namespace Bloatless\WebSocket\Application;
 
 use Bloatless\WebSocket\Connection;
 
-class StatusApplication extends Application
+class StatusApplication extends LoggerAwareApplication
 {
     /**
      * Holds client connected to the status application.

--- a/src/Application/StatusApplication.php
+++ b/src/Application/StatusApplication.php
@@ -164,6 +164,7 @@ class StatusApplication extends Application
         ];
         $encodedData = $this->encodeData('statusMsg', $data);
         $this->sendAll($encodedData);
+        $this->getLogger()->log($type, 'Status message: ' . $text);
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bloatless\WebSocket;
 
 use Bloatless\WebSocket\Application\ApplicationInterface;
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -142,7 +143,7 @@ class Server
 
         while (true) {
             $this->timers->runAll();
-          
+
             $changed_sockets = $this->allsockets;
             @stream_select($changed_sockets, $write, $except, 0, 5000);
             foreach ($changed_sockets as $socket) {
@@ -246,6 +247,10 @@ class Server
     public function registerApplication(string $key, ApplicationInterface $application): void
     {
         $this->applications[$key] = $application;
+
+        if ($application instanceof LoggerAwareInterface) {
+            $application->setLogger($this->logger);
+        }
 
         // status is kind of a system-app, needs some special cases:
         if ($key === 'status') {


### PR DESCRIPTION
This PR adds support for the `LoggerAwareInterface` by passing the servers Logger to the application being registered.

This way, applications can log to the same interface as the server while maintaining full backwards compatibility.